### PR TITLE
substitute slashes to backslashes in filepaths when #ifndef WIN

### DIFF
--- a/src/generics/filesystem_handlers/os_filesystem_elements.c
+++ b/src/generics/filesystem_handlers/os_filesystem_elements.c
@@ -93,6 +93,14 @@ char* wfilename_to_locale_filename(const wchar_t* wfn)
     return 0;
   }
 
+  int index = 0;
+  while(locenc_buf[index])
+  {
+          if(locenc_buf[index] == '\\')
+                  locenc_buf[index] = '/';
+          index++;
+  }
+
   return locenc_buf;
 }
 #endif


### PR DESCRIPTION
The windows version puts backslashes in filepaths in the XML/MHL file and it makes the mhl_tool unusable under linux.